### PR TITLE
Feature ktps 461 sanity check energy split coefficients

### DIFF
--- a/openstf/model/split_energy.py
+++ b/openstf/model/split_energy.py
@@ -53,13 +53,9 @@ def split_energy(pid):
     if not invalid_coefs.empty:
         # If coefs not valid, do not update the coefs in the db and send teams
         # message that something strange is happening
-        df_to_str = [
-            f"\ncoefficient: {row.coef_name}, new coefficient: {row.coef_value_new}, last coefficient: {row.coef_value_last}"
-            for row in invalid_coefs.iterrows()
-        ]
         monitoring.post_teams_alert(
-            f"New splitting coefficient(s) {list(invalid_coefs.coef_name)} for pid {pj['id']} deviate strongly from previously stored coefficients."
-            + df_to_str,
+            f"New splitting coefficient(s) {list(invalid_coefs.coef_name)} for pid {pj['id']} deviate strongly from previously stored coefficients.",
+            invalid_coefs=invalid_coefs,
             coefsdf=coefsdf,
         )
         # Use the last known coefficients for further processing

--- a/openstf/monitoring/teams.py
+++ b/openstf/monitoring/teams.py
@@ -80,7 +80,7 @@ def post_teams(msg, url=None):
     card.send()
 
 
-def post_teams_alert(msg, url=None):
+def post_teams_alert(msg, coefsdf=None, url=None):
     """Same as post_teams, but posts to alert channel.
 
     Args:
@@ -95,12 +95,38 @@ def post_teams_alert(msg, url=None):
 
     """
     config = ConfigManager.get_instance()
+    # Add manual coefficients-query to message
+    if coefsdf is not None:
+        query = build_sql_query_string(coefsdf, "energy_split_coefs")
+        msg = f"{msg}. If you would like to update the coefficients manually, use this query:\n {query}"
 
     if url is None:
         if hasattr(config, "teams") is True:
             url = config.teams.alert_url
 
     return post_teams(msg, url=url)
+
+
+def build_sql_query_string(df, table):
+    """Build sql insert query string for Teams message output from df.
+
+    Args:
+        df (pd.DataFrame): df of table values to insert in sql
+        table (string): table to insert df into
+
+    Returns:
+        string: sql query string of insert statement
+    """
+    sql_texts = [
+        "INSERT INTO " + table + " (" + str(", ".join(df.columns)) + ") VALUES \n"
+    ]
+    for index, row in df.iterrows():
+        if index != df.index[0]:
+            sql_texts.append(",\n")
+        sql_texts.append(str(tuple(row.values)))
+
+    query = "".join(sql_texts)
+    return query
 
 
 def send_report_teams_better(pj, feature_importance):

--- a/openstf/monitoring/teams.py
+++ b/openstf/monitoring/teams.py
@@ -80,25 +80,32 @@ def post_teams(msg, url=None):
     card.send()
 
 
-def post_teams_alert(msg, coefsdf=None, url=None):
+def post_teams_alert(msg, invalid_coefs=None, coefsdf=None, url=None):
     """Same as post_teams, but posts to alert channel.
 
     Args:
-    msg (mixed): For simple messages a string can be passed. For more
+        msg (mixed): For simple messages a string can be passed. For more
             complex messages pass a dict. The following keys are supported:
             text, links, sections. Each section is a dict and can contain the
             following keys: text, title, images, facts, markdown. Also see:
             https://docs.microsoft.com/en-us/outlook/actionable-messages/send-via-connectors
-
+        invalid_coefs (pd.DatFrame, optional): df of information of invalid coefficients. Defaults to None.
+        coefsdf (pd.DataFrame, optional): df of new coefficients. Defaults to None.
     Note:
         This function is namespace-specific.
-
     """
+    test = 1
     config = ConfigManager.get_instance()
     # Add manual coefficients-query to message
-    if coefsdf is not None:
+    if invalid_coefs is not None and coefsdf is not None:
+        invalid_coefs_str = "".join(
+            [
+                f"\ncoefficient name: {row.coef_name}, new value: {row.coef_value_new}, last value: {row.coef_value_last}"
+                for index, row in invalid_coefs.iterrows()
+            ]
+        )
         query = build_sql_query_string(coefsdf, "energy_split_coefs")
-        msg = f"{msg}. If you would like to update the coefficients manually, use this query:\n {query}"
+        msg = f"{msg}. {invalid_coefs_str}\nIf you would like to update the coefficients manually, use this query:\n {query}"
 
     if url is None:
         if hasattr(config, "teams") is True:

--- a/openstf/monitoring/teams.py
+++ b/openstf/monitoring/teams.py
@@ -94,9 +94,8 @@ def post_teams_alert(msg, invalid_coefs=None, coefsdf=None, url=None):
     Note:
         This function is namespace-specific.
     """
-    test = 1
     config = ConfigManager.get_instance()
-    # Add manual coefficients-query to message
+    # Add invalid coefficients and manual coefficients-query to message
     if invalid_coefs is not None and coefsdf is not None:
         invalid_coefs_str = "".join(
             [

--- a/test/unit/model/test_split_energy.py
+++ b/test/unit/model/test_split_energy.py
@@ -20,35 +20,49 @@ class TestSplitEnergy(BaseTestCase):
         testcomponents, coefdict = split_energy.find_components(input_data)
         self.assertDataframeEqual(components, testcomponents, rtol=1e-3)
 
-    threshold = split_energy.COEF_MAX_PCT_DIFF
+    threshold = split_energy.COEF_MAX_FRACTION_DIFF
 
     def test_are_coefs_valid_true(self):
         new_coefs = {"a": 1, "b": 1, "c": -1}
-        mean_coefs = {"a": 1, "b": 1 + self.threshold, "c": -1}
+        last_coefs = {"a": 1, "b": 1 + self.threshold, "c": -1}
 
-        result = split_energy.are_new_coefs_valid(new_coefs, mean_coefs)
-        self.assertTrue(result)
+        result = split_energy.are_new_coefs_valid(new_coefs, last_coefs)
+        self.assertIsNone(result)
 
     def test_are_coefs_valid_flipped_sign(self):
         new_coefs = {"a": 1, "b": 1}
-        mean_coefs = {"a": 1, "b": -1}
+        last_coefs = {"a": 1, "b": -1}
 
-        result = split_energy.are_new_coefs_valid(new_coefs, mean_coefs)
-        self.assertFalse(result)
+        result = split_energy.are_new_coefs_valid(new_coefs, last_coefs)
+        self.assertEqual(result, "b")
 
     def test_are_coefs_valid_above_threshold(self):
         new_coefs = {"a": 1, "b": 1}
-        mean_coefs = {"a": 1, "b": 1 + 1.5 * self.threshold}
+        last_coefs = {"a": 1, "b": 1 + 1.5 * self.threshold}
 
-        result = split_energy.are_new_coefs_valid(new_coefs, mean_coefs)
-        self.assertFalse(result)
+        result = split_energy.are_new_coefs_valid(new_coefs, last_coefs)
+        self.assertEqual(result, "b")
 
     def test_are_coefs_valid_below_threshold(self):
         new_coefs = {"a": 1, "b": 1}
-        mean_coefs = {"a": 1, "b": 1 - self.threshold}
+        last_coefs = {"a": 1, "b": 1 - self.threshold}
 
-        result = split_energy.are_new_coefs_valid(new_coefs, mean_coefs)
-        self.assertFalse(result)
+        result = split_energy.are_new_coefs_valid(new_coefs, last_coefs)
+        self.assertEqual(result, "b")
+
+    def test_are_coefs_valid_multiple_failing_keys(self):
+        new_coefs = {"a": 1, "b": 1, "c": 1}
+        last_coefs = {"a": 1, "b": 1 - self.threshold, "c": -1}
+
+        result = split_energy.are_new_coefs_valid(new_coefs, last_coefs)
+        self.assertEqual(result, "b")
+
+    def test_are_coefs_valid_no_matching_key(self):
+        new_coefs = {"a": 1, "b": 1}
+        last_coefs = {"a": 1, "c": 1}
+
+        result = split_energy.are_new_coefs_valid(new_coefs, last_coefs)
+        self.assertIsNone(result)
 
 
 # Run all tests

--- a/test/unit/model/test_split_energy.py
+++ b/test/unit/model/test_split_energy.py
@@ -22,7 +22,7 @@ class TestSplitEnergy(BaseTestCase):
 
     threshold = split_energy.COEF_MAX_FRACTION_DIFF
 
-    def test_are_coefs_valid_true(self):
+    def test_determine_invalid_coefs_valid(self):
         new_coefs = pd.DataFrame(
             {"coef_name": ["a", "b", "c"], "coef_value": [1, 1, -1]}
         )
@@ -36,7 +36,6 @@ class TestSplitEnergy(BaseTestCase):
                 "coef_value_last",
                 "coef_value_new",
                 "difference",
-                "invalid_coef",
             ],
         )
         result = split_energy.determine_invalid_coefs(new_coefs, last_coefs)
@@ -44,7 +43,7 @@ class TestSplitEnergy(BaseTestCase):
             result, expected_result, check_dtype=False, check_index_type=False
         )
 
-    def test_are_coefs_valid_flipped_sign(self):
+    def test_determine_invalid_coefs_flipped_sign(self):
         new_coefs = pd.DataFrame({"coef_name": ["a", "b"], "coef_value": [1, 1]})
         last_coefs = pd.DataFrame({"coef_name": ["a", "b"], "coef_value": [1, -1]})
 
@@ -54,14 +53,13 @@ class TestSplitEnergy(BaseTestCase):
                 "coef_value_last": [-1],
                 "coef_value_new": [1],
                 "difference": [2],
-                "invalid_coef": [True],
             },
             index=[1],
         )
         result = split_energy.determine_invalid_coefs(new_coefs, last_coefs)
         self.assertDataframeEqual(result, expected_result, check_index_type=False)
 
-    def test_are_coefs_valid_above_threshold(self):
+    def test_determine_invalid_coefs_above_threshold(self):
         new_coefs = pd.DataFrame({"coef_name": ["a", "b"], "coef_value": [1, 1]})
         last_coefs = pd.DataFrame(
             {"coef_name": ["a", "b"], "coef_value": [1, 1 + 1.5 * self.threshold]}
@@ -73,14 +71,13 @@ class TestSplitEnergy(BaseTestCase):
                 "coef_value_last": [1 + 1.5 * self.threshold],
                 "coef_value_new": [1],
                 "difference": [1.5 * self.threshold],
-                "invalid_coef": [True],
             },
             index=[1],
         )
         result = split_energy.determine_invalid_coefs(new_coefs, last_coefs)
         self.assertDataframeEqual(result, expected_result, check_index_type=False)
 
-    def test_are_coefs_valid_below_threshold(self):
+    def test_determine_invalid_coefs_below_threshold(self):
         new_coefs = pd.DataFrame({"coef_name": ["a", "b"], "coef_value": [1, 1]})
         last_coefs = pd.DataFrame(
             {"coef_name": ["a", "b"], "coef_value": [1, 1 - self.threshold]}
@@ -92,14 +89,13 @@ class TestSplitEnergy(BaseTestCase):
                 "coef_value_last": [1 - self.threshold],
                 "coef_value_new": [1],
                 "difference": [self.threshold],
-                "invalid_coef": [True],
             },
             index=[1],
         )
         result = split_energy.determine_invalid_coefs(new_coefs, last_coefs)
         self.assertDataframeEqual(result, expected_result, check_index_type=False)
 
-    def test_are_coefs_valid_multiple_failing_keys(self):
+    def test_determine_invalid_coefs_multiple_failing_keys(self):
         new_coefs = pd.DataFrame(
             {"coef_name": ["a", "b", "c"], "coef_value": [1, 1, 1]}
         )
@@ -113,14 +109,13 @@ class TestSplitEnergy(BaseTestCase):
                 "coef_value_last": [1 - self.threshold, -1],
                 "coef_value_new": [1, 1],
                 "difference": [self.threshold, 2],
-                "invalid_coef": [True],
             },
             index=[1, 2],
         )
         result = split_energy.determine_invalid_coefs(new_coefs, last_coefs)
         self.assertDataframeEqual(result, expected_result, check_index_type=False)
 
-    def test_are_coefs_valid_no_matching_key(self):
+    def test_determine_invalid_coefs_no_matching_key(self):
         new_coefs = pd.DataFrame({"coef_name": ["a", "b"], "coef_value": [1, 1]})
         last_coefs = pd.DataFrame({"coef_name": ["a", "c"], "coef_value": [1, 1]})
 
@@ -130,7 +125,6 @@ class TestSplitEnergy(BaseTestCase):
                 "coef_value_last": [1],
                 "coef_value_new": [np.nan],
                 "difference": [np.inf],
-                "invalid_coef": [True],
             },
             index=[1],
         )

--- a/test/unit/model/test_split_energy.py
+++ b/test/unit/model/test_split_energy.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import unittest
+from numpy import split
+
+from numpy.core.fromnumeric import mean
 from test.utils import BaseTestCase, TestData
 
 from openstf.model import split_energy
@@ -16,6 +19,36 @@ class TestSplitEnergy(BaseTestCase):
     def test_find_components(self):
         testcomponents, coefdict = split_energy.find_components(input_data)
         self.assertDataframeEqual(components, testcomponents, rtol=1e-3)
+
+    threshold = split_energy.COEF_MAX_PCT_DIFF
+
+    def test_are_coefs_valid_true(self):
+        new_coefs = {"a": 1, "b": 1, "c": -1}
+        mean_coefs = {"a": 1, "b": 1 + self.threshold, "c": -1}
+
+        result = split_energy.are_new_coefs_valid(new_coefs, mean_coefs)
+        self.assertTrue(result)
+
+    def test_are_coefs_valid_flipped_sign(self):
+        new_coefs = {"a": 1, "b": 1}
+        mean_coefs = {"a": 1, "b": -1}
+
+        result = split_energy.are_new_coefs_valid(new_coefs, mean_coefs)
+        self.assertFalse(result)
+
+    def test_are_coefs_valid_above_threshold(self):
+        new_coefs = {"a": 1, "b": 1}
+        mean_coefs = {"a": 1, "b": 1 + 1.5 * self.threshold}
+
+        result = split_energy.are_new_coefs_valid(new_coefs, mean_coefs)
+        self.assertFalse(result)
+
+    def test_are_coefs_valid_below_threshold(self):
+        new_coefs = {"a": 1, "b": 1}
+        mean_coefs = {"a": 1, "b": 1 - self.threshold}
+
+        result = split_energy.are_new_coefs_valid(new_coefs, mean_coefs)
+        self.assertFalse(result)
 
 
 # Run all tests

--- a/test/unit/monitoring/test_teams.py
+++ b/test/unit/monitoring/test_teams.py
@@ -34,6 +34,15 @@ class TestTeams(BaseTestCase):
         card_mock = teamsmock.connectorcard.return_value
         self.assertTrue(card_mock.send.called)
 
+    def test_build_sql_query_string(self, teamsmock):
+        query_df = pd.DataFrame(data=[["a", 1], ["b", 2]], columns=["key", "value"])
+        table = "table"
+
+        query_expected = "INSERT INTO table (key, value) VALUES \n('a', 1),\n('b', 2)"
+
+        query_result = teams.build_sql_query_string(query_df, table)
+        self.assertEqual(query_result, query_expected)
+
     def test_post_teams_better(self, teamsmock):
 
         test_feature_weights = pd.DataFrame(data={"gain": [1, 2]})

--- a/test/unit/monitoring/test_teams.py
+++ b/test/unit/monitoring/test_teams.py
@@ -34,6 +34,22 @@ class TestTeams(BaseTestCase):
         card_mock = teamsmock.connectorcard.return_value
         self.assertTrue(card_mock.send.called)
 
+    def test_post_teams_alert_invalid_keys(self, teamsmock):
+
+        msg = "test"
+        invalid_coefs = pd.DataFrame(
+            {
+                "coef_name": ["a"],
+                "coef_value_last": [0],
+                "coef_value_new": [1],
+            },
+        )
+        coefsdf = pd.DataFrame()
+
+        teams.post_teams_alert(msg, invalid_coefs=invalid_coefs, coefsdf=coefsdf)
+        card_mock = teamsmock.connectorcard.return_value
+        self.assertTrue(card_mock.send.called)
+
     def test_build_sql_query_string(self, teamsmock):
         query_df = pd.DataFrame(data=[["a", 1], ["b", 2]], columns=["key", "value"])
         table = "table"


### PR DESCRIPTION
I added the sanity check for coefficients for energy splitting with variable threshold `COEF_MAX_PCT_DIFF`. In case the check fails, a message is sent to Teams with a manual insert sql statement.

I tried to keep the Alliander-specific code in `teams.py` as much as possible.