### PR TITLE
change splitting_energy teams communication from alerts to monitoring

### DIFF
--- a/openstf/model/figure.py
+++ b/openstf/model/figure.py
@@ -69,7 +69,7 @@ def plot_data_series(data, predict_data=None, horizon=47, names=None):
     series_names = {
         1: ("series",),
         2: ("train", "validation"),
-        3: ("train", "validation", "test")
+        3: ("train", "validation", "test"),
     }
 
     num_series = len(data)

--- a/openstf/model/split_energy.py
+++ b/openstf/model/split_energy.py
@@ -54,7 +54,7 @@ def split_energy(pid):
     if not invalid_coefs.empty:
         # If coefs not valid, do not update the coefs in the db and send teams
         # message that something strange is happening
-        monitoring.post_teams_alert(
+        monitoring.post_teams(
             f"New splitting coefficient(s) for pid **{pj['id']}** deviate strongly "
             f"from previously stored coefficients.",
             invalid_coefs=invalid_coefs,

--- a/openstf/monitoring/teams.py
+++ b/openstf/monitoring/teams.py
@@ -8,7 +8,7 @@ from ktpbase.config.config import ConfigManager
 from ktpbase.log import logging
 
 
-def post_teams(msg, url=None):
+def post_teams(msg, invalid_coefs=None, coefsdf=None, url=None):
     """Post a message to Teams - KTP
 
     Note that currently no authentication occurs.
@@ -22,6 +22,9 @@ def post_teams(msg, url=None):
             text, links, sections. Each section can contain the following keys:
             text, title, images, facts, markdown. Also see:
             https://docs.microsoft.com/en-us/outlook/actionable-messages/send-via-connectors
+        invalid_coefs (pd.DatFrame, optional): df of information of invalid
+            coefficients. Defaults to None.
+        coefsdf (pd.DataFrame, optional): df of new coefficients. Defaults to None.
         url (string, optional): webhook url, monitoring by default
 
     Note:
@@ -30,6 +33,42 @@ def post_teams(msg, url=None):
     """
     config = ConfigManager.get_instance()
     logger = logging.get_logger(__name__)
+
+    # Add invalid coefficients and manual coefficients-query to message
+    if invalid_coefs is not None and coefsdf is not None:
+        # add invalid coefficient information to message in dict-format
+        invalid_coefs_text = "".join(
+            [
+                f"\n* **{row.coef_name}**: {round(row.coef_value_new, 2)}, "
+                f"(previous: {round(row.coef_value_last, 2)})"
+                for index, row in invalid_coefs.iterrows()
+            ]
+        )
+        query = build_sql_query_string(coefsdf, "energy_split_coefs")
+        query_text = (
+            "If you would like to update the coefficients manually in the "
+            + "database, use this query:"
+        )
+        msg = {
+            "fallback": msg,
+            "title": "Invalid energy splitting coefficients",
+            "text": msg,
+            "sections": [
+                {
+                    "text": invalid_coefs_text,
+                    "markdown": True,
+                },
+                {
+                    "title": "Manual query",
+                    "text": query_text,
+                    "markdown": True,
+                },
+                {
+                    "text": query,
+                    "markdown": True,
+                },
+            ],
+        }
 
     # if Teams url is not configured just return
     if url is None and (
@@ -80,7 +119,7 @@ def post_teams(msg, url=None):
     card.send()
 
 
-def post_teams_alert(msg, invalid_coefs=None, coefsdf=None, url=None):
+def post_teams_alert(msg, url=None):
     """Same as post_teams, but posts to alert channel.
 
     Args:
@@ -89,49 +128,11 @@ def post_teams_alert(msg, invalid_coefs=None, coefsdf=None, url=None):
             text, links, sections. Each section is a dict and can contain the
             following keys: text, title, images, facts, markdown. Also see:
             https://docs.microsoft.com/en-us/outlook/actionable-messages/send-via-connectors
-        invalid_coefs (pd.DatFrame, optional): df of information of invalid
-            coefficients. Defaults to None.
-        coefsdf (pd.DataFrame, optional): df of new coefficients. Defaults to None.
+
     Note:
         This function is namespace-specific.
     """
     config = ConfigManager.get_instance()
-    # Add invalid coefficients and manual coefficients-query to message
-    if invalid_coefs is not None and coefsdf is not None:
-        # add invalid coefficient information to message in dict-format
-        invalid_coefs_text = "".join(
-            [
-                f"\n* **{row.coef_name}**: {round(row.coef_value_new, 2)}, "
-                f"(previous: {round(row.coef_value_last, 2)})"
-                for index, row in invalid_coefs.iterrows()
-            ]
-        )
-        query = build_sql_query_string(coefsdf, "energy_split_coefs")
-        query_text = "If you would like to update the coefficients manually in the "
-        f"database, use this query:"
-        msg = {
-            "fallback": msg,
-            "title": "Invalid energy splitting coefficients",
-            "sections": [
-                {
-                    "text": msg,
-                    "markdown": True,
-                },
-                {
-                    "text": invalid_coefs_text,
-                    "markdown": True,
-                },
-                {
-                    "title": "Manual query",
-                    "text": query_text,
-                    "markdown": True,
-                },
-                {
-                    "text": query,
-                    "markdown": True,
-                },
-            ],
-        }
     if url is None:
         if hasattr(config, "teams") is True:
             url = config.teams.alert_url
@@ -159,13 +160,17 @@ def build_sql_query_string(df, table):
         df[col] = df[col].astype("str")
 
     sql_texts = [
-        "```INSERT INTO " + table + " (" + str(", ".join(df.columns)) + ") VALUES  \n"
+        "```  \nINSERT INTO "
+        + table
+        + " ("
+        + str(", ".join(df.columns))
+        + ") VALUES  \n"
     ]
     for index, row in df.iterrows():
         if index != df.index[0]:
             sql_texts.append(",  \n")  # 2 spaces and \n create a new line
         sql_texts.append(str(tuple(row.values)))
-    sql_texts.append("```")
+    sql_texts.append("  \n```")
     query = "".join(sql_texts)
     return query
 

--- a/test/unit/monitoring/test_teams.py
+++ b/test/unit/monitoring/test_teams.py
@@ -34,7 +34,7 @@ class TestTeams(BaseTestCase):
         card_mock = teamsmock.connectorcard.return_value
         self.assertTrue(card_mock.send.called)
 
-    def test_post_teams_alert_invalid_keys(self, teamsmock):
+    def test_post_teams_invalid_keys(self, teamsmock):
 
         msg = "test"
         invalid_coefs = pd.DataFrame(
@@ -46,7 +46,7 @@ class TestTeams(BaseTestCase):
         )
         coefsdf = pd.DataFrame()
 
-        teams.post_teams_alert(msg, invalid_coefs=invalid_coefs, coefsdf=coefsdf)
+        teams.post_teams(msg, invalid_coefs=invalid_coefs, coefsdf=coefsdf)
         card_mock = teamsmock.connectorcard.return_value
         self.assertTrue(card_mock.send.called)
 

--- a/test/unit/monitoring/test_teams.py
+++ b/test/unit/monitoring/test_teams.py
@@ -54,9 +54,7 @@ class TestTeams(BaseTestCase):
         query_df = pd.DataFrame(data=[["a", 1], ["b", 2]], columns=["key", "value"])
         table = "table"
 
-        query_expected = (
-            "```INSERT INTO table (key, value) VALUES  \n('a', 1),  \n('b', 2)```"
-        )
+        query_expected = "```  \nINSERT INTO table (key, value) VALUES  \n('a', 1),  \n('b', 2)  \n```"
 
         query_result = teams.build_sql_query_string(query_df, table)
         self.assertEqual(query_result, query_expected)


### PR DESCRIPTION
I have changed the message for an invalid energy splitting coefficients from alert to monitoring. Next to that, the markdown did something weird and fixed that as well.

I see that `post_teams()` has a code smell, but after discussions last time we decided to add an `if-statement` in the function, instead of creating a dedicated function for `post_teams_invalid_splitting_coef()`. Do we still want that? Or I can add a subfunction within `post_teams()` to build the invalid energy splitting coefficients message?

I solved the markdown issue by adding newlines.