### PR TITLE
Feature ktps 490 refactor train function

### DIFF
--- a/openstf/model/train.py
+++ b/openstf/model/train.py
@@ -243,15 +243,19 @@ def predict_after_training_for_specific_pj(pj, model_trainer, split_input_data):
         model_trainer.confidence_interval,
     )
     train_predict = predictor.make_forecast(
-        split_input_data.train_data.iloc[:, 1:].drop("Horizon", axis=1, errors="ignore")
+        split_input_data["train_data"]
+        .iloc[:, 1:]
+        .drop("Horizon", axis=1, errors="ignore")
     )
     validation_predict = predictor.make_forecast(
-        split_input_data.validation_data.iloc[:, 1:].drop(
-            "Horizon", axis=1, errors="ignore"
-        )
+        split_input_data["validation_data"]
+        .iloc[:, 1:]
+        .drop("Horizon", axis=1, errors="ignore")
     )
     test_predict = predictor.make_forecast(
-        split_input_data.test_data.iloc[:, 1:].drop("Horizon", axis=1, errors="ignore")
+        split_input_data["test_data"]
+        .iloc[:, 1:]
+        .drop("Horizon", axis=1, errors="ignore")
     )
 
     return {
@@ -276,8 +280,8 @@ def create_evaluation_figures_for_specific_pj(
     Returns:
         tuple: tuple containing:
             plotly.graph_objects.Figure: A treemap of the features.
-            plotly.graph_objects.Figure: A line plot of of split input and predicted
-                data series.
+            dict: dict of line plots of of split input and predicted
+                data series per prediction horizon.
     """
 
     # Create figures
@@ -288,7 +292,7 @@ def create_evaluation_figures_for_specific_pj(
             list(split_predicted_data.values()),
             horizon,
         )
-        for horizon in split_input_data.train_data.Horizon.unique()
+        for horizon in split_input_data["train_data"].Horizon.unique()
     }
     return figure_features, figure_series
 
@@ -323,7 +327,9 @@ def evaluate_new_model_for_specific_pj(
     )
 
     # Combine validation + train data
-    combined = split_input_data.train_data.append(split_input_data.validation_data)
+    combined = split_input_data["train_data"].append(
+        split_input_data["validation_data"]
+    )
 
     # Evaluate model and store if better than old model
     # TODO Use predicted data series created above instead of predicting again

--- a/openstf/monitoring/teams.py
+++ b/openstf/monitoring/teams.py
@@ -108,7 +108,7 @@ def post_teams_alert(msg, invalid_coefs=None, coefsdf=None, url=None):
         )
         query = build_sql_query_string(coefsdf, "energy_split_coefs")
         query_text = "If you would like to update the coefficients manually in the "
-        f"database, use this query:"
+        "database, use this query:"
         msg = {
             "fallback": msg,
             "title": "Invalid energy splitting coefficients",

--- a/openstf/tasks/train_model.py
+++ b/openstf/tasks/train_model.py
@@ -22,7 +22,7 @@ Example:
         $ python model_train.py
 
 """
-from openstf.model.train import train_model_for_specific_pj
+from openstf.model.train import train_model_pipeline
 from openstf.tasks.utils.predictionjobloop import PredictionJobLoop
 from openstf.tasks.utils.taskcontext import TaskContext
 
@@ -32,7 +32,7 @@ def main():
         model_type = ["xgb", "xgb_quantile", "lgb"]
 
         PredictionJobLoop(context, model_type=model_type).map(
-            train_model_for_specific_pj, context
+            train_model_pipeline, context
         )
 
 

--- a/openstf/tasks/utils/taskcontext.py
+++ b/openstf/tasks/utils/taskcontext.py
@@ -37,7 +37,7 @@ class TaskContext:
             post_teams_on_exception (bool, optional): If set to True the context
                 manager will automatically post a message to teams when an
                 exception is encountered. Defaults to True.
-            oon_exception (callable, optional): Callback, will be called
+            on_exception (callable, optional): Callback, will be called
                 when an exception is raised. Callable gets exc_type, exc_info,
                 stack_info as arguments.
             on_successful (callable, optional): Callback, will be called

--- a/test/unit/model/test_train.py
+++ b/test/unit/model/test_train.py
@@ -4,8 +4,9 @@
 
 from datetime import datetime, timedelta
 from test.utils.data import TestData
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import unittest
+from plotly import graph_objects as go
 
 import numpy as np
 import pandas as pd
@@ -13,7 +14,15 @@ import pandas as pd
 from openstf.model.general import MLModelType, split_data_train_validation_test
 from openstf.model.serializer.creator import ModelSerializerCreator
 from openstf.model.serializer.xgboost.xgboost import XGBModelSerializer
-from openstf.model.train import is_data_sufficient
+from openstf.model.train import (
+    is_data_sufficient,
+    create_model_for_specific_pj,
+    preprocess_for_specific_pj,
+    predict_after_training_for_specific_pj,
+    create_evaluation_figures_for_specific_pj,
+    evaluate_new_model_for_specific_pj,
+    MAX_AGE_YOUNG_MODEL,
+)
 from openstf.model.trainer.creator import ModelTrainerCreator
 from openstf.model.trainer.xgboost.xgboost import XGBModelTrainer
 
@@ -40,6 +49,33 @@ params = {
     "objective": "reg:linear",
 }
 
+pj_mock = MagicMock()
+context_mock = MagicMock()
+model_trainer_mock = MagicMock()
+
+split_input_data = {
+    "train_data": pd.DataFrame({"Horizon": [24]}),
+    "validation_data": pd.DataFrame(),
+    "test_data": pd.DataFrame(),
+}
+split_predicted_data = {
+    "train_predict": None,
+    "validation_predict": None,
+    "test_predict": None,
+}
+
+
+# def model_trainer_mock():
+#     model_trainer = MagicMock()
+#     model_trainer.old_model_age = MagicMock(return_value=6)
+#     return model_trainer
+
+
+def model_trainer_creator_mock(pj):
+    model_trainer_creator = MagicMock()
+    model_trainer_creator.create_model_trainer = model_trainer_mock()
+    return model_trainer_creator
+
 
 class TestTrain(BaseTestCase):
     def setUp(self) -> None:
@@ -60,10 +96,141 @@ class TestTrain(BaseTestCase):
             "colsample_bytree": 0.85,
             "silent": 1,
             "objective": "reg:squarederror",
+            "training_period_days": 7,
+            "featureset_name": "D",
         }
         self.model_trainer_ref = XGBModelTrainer(pj)
         self.model_trainer_ref.hyper_parameters.update(params)
         self.model_trainer_ref.train(self.training_data_ref, self.validation_data_ref)
+
+    # def test_create_model_for_specific_pj_retrain_young_models_true(
+    #     self,
+    # ):
+    #     context = MagicMock()
+
+    #     result = create_model_for_specific_pj(pj, context, retrain_young_models=True)
+    #     self.assertEqual(model_trainer_mock.call_count, 1)
+    #     self.assertEqual(result, model_trainer_mock)
+
+    # # @patch(
+    # #     "openstf.model.train.model_trainer.old_model_age",
+    # #     MagicMock(return_value=MAX_AGE_YOUNG_MODEL + 1),
+    # # )
+    # def test_create_model_for_specific_pj_retrain_young_models_false(self):
+    #     context = MagicMock()
+    #     result = create_model_for_specific_pj(pj, context, retrain_young_models=False)
+    #     # context logger gecalled
+    #     self.assertEqual(context.logger.info.call_count, 1)
+    #     self.assertEqual(model_trainer_mock.old_model_age.call_count, 1)
+    #     self.assertIsNone(result)
+
+    @patch("openstf.model.train.pre_process_data")
+    @patch("openstf.model.train.is_data_sufficient")
+    @patch(
+        "openstf.model.train.split_data_train_validation_test",
+        MagicMock(return_value=[None, None, None]),
+    )
+    def test_preprocess_for_specific_pj(
+        self,
+        is_data_sufficient_mock,
+        pre_process_data_mock,
+    ):
+        result = preprocess_for_specific_pj(pj_mock, context_mock)
+        result_expected = {
+            "train_data": None,
+            "validation_data": None,
+            "test_data": None,
+        }
+
+        self.assertEqual(pre_process_data_mock.call_count, 1)
+        self.assertEqual(is_data_sufficient_mock.call_count, 1)
+
+        self.assertEqual(result, result_expected)
+
+    @patch("openstf.model.train.PredictionModelCreator")
+    def test_predict_after_training_for_specific_pj(
+        self,
+        prediction_model_creator_mock,
+    ):
+        result = predict_after_training_for_specific_pj(
+            pj_mock, model_trainer_mock, split_input_data
+        )
+        # return dict with three keys
+        result_expected = split_predicted_data
+
+        self.assertEqual(result.keys(), result_expected.keys())
+
+    @patch(
+        "openstf.model.train.plot_feature_importance",
+        MagicMock(return_value=go.Figure()),
+    )
+    @patch("openstf.model.train.plot_data_series", MagicMock(return_value=go.Figure()))
+    def test_create_evaluation_figures_for_specific_pj(self):
+        model_trainer = MagicMock()
+
+        result = create_evaluation_figures_for_specific_pj(
+            model_trainer, split_input_data, split_predicted_data
+        )
+        expected_result = go.Figure(), {"Predictor24": go.Figure()}
+
+        self.assertEqual(result, expected_result)
+
+    # @patch(
+    #     "openstf.model.train.model_trainer.better_than_old_model",
+    #     MagicMock(return_value=True),
+    # )
+
+    @patch("openstf.model.train.send_report_teams_better")
+    @patch("openstf.model.train.os.makedirs")
+    @patch(
+        "openstf.model.train.create_evaluation_figures_for_specific_pj",
+        MagicMock(return_value=(go.Figure(), go.Figure())),
+    )
+    def test_evaluate_new_model_for_specific_pj_compare_to_old_true(
+        self,
+        makedirs_mock,
+        send_report_teams_better_mock,
+    ):
+
+        evaluate_new_model_for_specific_pj(
+            pj_mock,
+            context_mock,
+            model_trainer_mock,
+            split_input_data,
+            split_predicted_data,
+            compare_to_old=True,
+        )
+
+        self.assertEqual(makedirs_mock.call_count, 1)
+        self.assertEqual(send_report_teams_better_mock.call_count, 1)
+
+    # @patch(
+    #     "openstf.model.train.model_trainer.better_than_old_model",
+    #     MagicMock(return_value=False),
+    # )
+    @patch("openstf.model.train.send_report_teams_worse")
+    @patch(
+        "openstf.model.train.create_evaluation_figures_for_specific_pj",
+        MagicMock(return_value=(go.Figure(), go.Figure())),
+    )
+    @patch("openstf.model.train.os.makedirs")
+    def test_evaluate_new_model_for_specific_pj_compare_to_old_false(
+        self,
+        makedirs_mock,
+        send_report_teams_worse_mock,
+    ):
+
+        evaluate_new_model_for_specific_pj(
+            pj_mock,
+            context_mock,
+            model_trainer_mock,
+            split_input_data,
+            split_predicted_data,
+            compare_to_old=False,
+        )
+
+        self.assertEqual(makedirs_mock.call_count, 1)
+        self.assertEqual(send_report_teams_worse_mock.call_count, 1)
 
     def test_model_trainer_creator(self):
         serializer_creator = ModelSerializerCreator()


### PR DESCRIPTION
I have refactored the function `train_model_for_specific_pj()`, and renamed it to `train_model_pipeline()`. Subfunctions are pulled apart and tested.

@bremme the change you suggested in test was not working after all (i showed you a succesfull pytest of another file..)