### PR TITLE
fix sonar coverage

### DIFF
--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: fix code coverage paths
       working-directory: ./coverage
       run: |
-        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' /github/workspace/coverage.xml
+        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' /home/runner/work/short-term-forecasting/short-term-forecasting/coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -54,7 +54,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov-report=xml --cov=openstf test/     
+        pytest --cov-report=xml --cov=openstf test/ --junitxml=pytest-report.xml    
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       env:

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -54,7 +54,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov-report=xml --cov=openstf/ test/ --junitxml=pytest-report.xml
+        pytest --cov-report=xml --cov=openstf/ test/unit/ --junitxml=pytest-report.xml
     # Fix relative paths in coverage file
     - name: fix code coverage paths
       run: |

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -54,12 +54,12 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov-report=xml --cov=openstf test/ --junitxml=pytest-report.xml
+        pytest --cov-report=xml --cov=openstf/ test/ --junitxml=pytest-report.xml
     # Fix relative paths in coverage file
     - name: fix code coverage paths
       working-directory: ./coverage
       run: |
-        sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
+        sed -i 's@'${{ GITHUB_WORKSPACE }}'@/github/workspace/@g' coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -54,12 +54,16 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov-report=xml:/github/workspace/coverage.xml --cov=openstf test/
+        pytest --cov-report=xml --cov=openstf test/     
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    - name: pytest-coverage-commentator
+      uses: coroo/pytest-coverage-commentator@v1.0.2
+      with:
+        pytest-coverage: coverage.xml   
     # Build
     - name: Build Python package
       run: |

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -56,10 +56,10 @@ jobs:
         pip install pytest pytest-cov
         pytest --cov-report=xml --cov=openstf/ test/ --junitxml=pytest-report.xml
     # Fix relative paths in coverage file
-    #- name: fix code coverage paths
-    #  working-directory: ./coverage
-    #  run: |
-    #    sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
+    - name: fix code coverage paths
+      working-directory: ./coverage
+      run: |
+        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\//g' coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -57,9 +57,8 @@ jobs:
         pytest --cov-report=xml --cov=openstf/ test/ --junitxml=pytest-report.xml
     # Fix relative paths in coverage file
     - name: fix code coverage paths
-      working-directory: ./coverage
       run: |
-        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' /home/runner/work/coverage.xml
+        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -58,7 +58,7 @@ jobs:
     # Fix relative paths in coverage file
     - name: fix code coverage paths
       run: |
-        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' coverage.xml
+        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\//g' coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: fix code coverage paths
       working-directory: ./coverage
       run: |
-        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' coverage.xml
+        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' /github/workspace/coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: fix code coverage paths
       working-directory: ./coverage
       run: |
-        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' /home/runner/work/short-term-forecasting/short-term-forecasting/coverage.xml
+        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' /home/runner/work/short-term-forecasting/coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -56,10 +56,10 @@ jobs:
         pip install pytest pytest-cov
         pytest --cov-report=xml --cov=openstf/ test/ --junitxml=pytest-report.xml
     # Fix relative paths in coverage file
-    - name: fix code coverage paths
-      working-directory: ./coverage
-      run: |
-        sed -i 's@'${{ GITHUB_WORKSPACE }}'@/github/workspace/@g' coverage.xml
+    #- name: fix code coverage paths
+    #  working-directory: ./coverage
+    #  run: |
+    #    sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: fix code coverage paths
       working-directory: ./coverage
       run: |
-        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\//g' coverage.xml
+        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -18,6 +18,8 @@ jobs:
     # Checkout
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     # Setup
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -54,16 +54,18 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov-report=xml --cov=openstf test/ --junitxml=pytest-report.xml    
+        pytest --cov-report=xml --cov=openstf test/ --junitxml=pytest-report.xml
+    # Fix relative paths in coverage file
+    - name: fix code coverage paths
+      working-directory: ./coverage
+      run: |
+        sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage.xml
+    # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    - name: pytest-coverage-commentator
-      uses: coroo/pytest-coverage-commentator@v1.0.2
-      with:
-        pytest-coverage: coverage.xml   
     # Build
     - name: Build Python package
       run: |

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: fix code coverage paths
       working-directory: ./coverage
       run: |
-        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' /home/runner/work/short-term-forecasting/coverage.xml
+        sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\/g' /home/runner/work/coverage.xml
     # Sonar cloud scan
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -56,6 +56,7 @@ jobs:
         pip install pytest pytest-cov
         pytest --cov-report=xml --cov=openstf/ test/unit/ --junitxml=pytest-report.xml
     # Fix relative paths in coverage file
+    # Known bug: https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057
     - name: fix code coverage paths
       run: |
         sed -i 's/\/home\/runner\/work\/short-term-forecasting\/short-term-forecasting\//\/github\/workspace\//g' coverage.xml

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -54,7 +54,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov-report=xml --cov=openstf test/
+        pytest --cov-report=xml:/github/workspace/coverage.xml --cov=openstf test/
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       env:

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -54,7 +54,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest pytest-cov
-        pytest --cov-report=xml --cov=openstf test/unit
+        pytest --cov-report=xml --cov=openstf test/
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       env:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,4 +9,4 @@ sonar.projectKey=alliander-opensource_short-term-forecasting
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=openstf
 sonar.python.coverage.reportPaths=/github/workspace/coverage.xml
-sonar.tests=test/unit
+sonar.tests=test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,5 +8,5 @@ sonar.projectKey=alliander-opensource_short-term-forecasting
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=openstf
-sonar.python.coverage.reportPath=/github/workspace/coverage.xml
+sonar.python.coverage.reportPaths=/github/workspace/coverage.xml
 sonar.tests=test/unit

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,4 +9,4 @@ sonar.projectKey=alliander-opensource_short-term-forecasting
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=openstf
 sonar.python.coverage.reportPaths=/github/workspace/coverage.xml
-sonar.tests=test
+sonar.tests=test/unit


### PR DESCRIPTION
Coverage reports were actually not correctly parsed. 
This is a known bug due to github action integration with pytest-cov and sonarcloud: https://community.sonarsource.com/t/sonar-on-github-actions-with-python-coverage-source-issue/36057

This PR seems to fix it:
![image](https://user-images.githubusercontent.com/18208480/114874348-88f4dc00-9dfc-11eb-99e5-e4bb5dd7cb72.png)
