### PR TITLE
log pid when fallbackforecast is used

### DIFF
--- a/openstf/model/prediction/prediction.py
+++ b/openstf/model/prediction/prediction.py
@@ -56,7 +56,7 @@ class AbstractPredictionModel(ABC):
             )
 
         self.logger.warning(
-            "Using failback forecast (*high forecast*)",
+            "Using fallback forecast (*high forecast*)",
             forecast_type="fallback",
             pid=self.pj["id"],
         )

--- a/openstf/model/prediction/prediction.py
+++ b/openstf/model/prediction/prediction.py
@@ -56,7 +56,7 @@ class AbstractPredictionModel(ABC):
             )
 
         self.logger.warning(
-            "Using failback forecast (*high forecast*)", forecast_type="fallback"
+            "Using failback forecast (*high forecast*)", forecast_type="fallback", pid=self.pj["id"]
         )
         forecast = self.predict_fallback(
             forecast_index=forecast_input_data.index, load=load_data

--- a/openstf/model/prediction/prediction.py
+++ b/openstf/model/prediction/prediction.py
@@ -56,7 +56,9 @@ class AbstractPredictionModel(ABC):
             )
 
         self.logger.warning(
-            "Using failback forecast (*high forecast*)", forecast_type="fallback", pid=self.pj["id"]
+            "Using failback forecast (*high forecast*)",
+            forecast_type="fallback",
+            pid=self.pj["id"],
         )
         forecast = self.predict_fallback(
             forecast_index=forecast_input_data.index, load=load_data


### PR DESCRIPTION
Super small change which adds logging of the pid when a fallbackforecast is used, for improved detectability in operations