### PR TITLE
add details for split coefs back

### DIFF
--- a/openstf/monitoring/teams.py
+++ b/openstf/monitoring/teams.py
@@ -34,6 +34,42 @@ def post_teams(msg, invalid_coefs=None, coefsdf=None, url=None):
     config = ConfigManager.get_instance()
     logger = structlog.get_logger(__name__)
 
+    # Add invalid coefficients and manual coefficients-query to message
+    if invalid_coefs is not None and coefsdf is not None:
+        # add invalid coefficient information to message in dict-format
+        invalid_coefs_text = "".join(
+            [
+                f"\n* **{row.coef_name}**: {round(row.coef_value_new, 2)}, "
+                f"(previous: {round(row.coef_value_last, 2)})"
+                for index, row in invalid_coefs.iterrows()
+            ]
+        )
+        query = build_sql_query_string(coefsdf, "energy_split_coefs")
+        query_text = (
+            "If you would like to update the coefficients manually in the "
+            + "database, use this query:"
+        )
+        msg = {
+            "fallback": msg,
+            "title": "Invalid energy splitting coefficients",
+            "text": msg,
+            "sections": [
+                {
+                    "text": invalid_coefs_text,
+                    "markdown": True,
+                },
+                {
+                    "title": "Manual query",
+                    "text": query_text,
+                    "markdown": True,
+                },
+                {
+                    "text": query,
+                    "markdown": True,
+                },
+            ],
+        }
+    
     # If no url is passed fall back to default
     if url is None:
         # if Teams url is not configured just return

--- a/openstf/monitoring/teams.py
+++ b/openstf/monitoring/teams.py
@@ -69,7 +69,7 @@ def post_teams(msg, invalid_coefs=None, coefsdf=None, url=None):
                 },
             ],
         }
-    
+
     # If no url is passed fall back to default
     if url is None:
         # if Teams url is not configured just return

--- a/openstf/monitoring/teams.py
+++ b/openstf/monitoring/teams.py
@@ -29,7 +29,6 @@ def post_teams(msg, invalid_coefs=None, coefsdf=None, url=None):
 
     Note:
         This function is namespace-specific.
-
     """
     config = ConfigManager.get_instance()
     logger = structlog.get_logger(__name__)


### PR DESCRIPTION
was added: https://github.com/alliander-opensource/short-term-forecasting/commit/17f3a43ffa75b33224ca150cdd8cfa3f1e093ad9#diff-c55b85529f55f88a29a6ef267f0b5f30c577a47e8f1503f16e3d27be1e27f354

was removed by accident: https://github.com/alliander-opensource/short-term-forecasting/commit/c747f2db0713935bc4f0b48614ca84e1e3fab635#diff-c55b85529f55f88a29a6ef267f0b5f30c577a47e8f1503f16e3d27be1e27f354