### PR TITLE
Bugfix KTPS-1408 Fallback forecast quantile model nan columns

### DIFF
--- a/openstf/model/prediction/prediction.py
+++ b/openstf/model/prediction/prediction.py
@@ -191,7 +191,9 @@ class AbstractPredictionModel(ABC):
         forecast["time"] = forecast.index.time
         forecast = (
             forecast.reset_index()
-            .merge(highest_daily_loadprofile, left_on="time", right_on="time", how="outer")
+            .merge(
+                highest_daily_loadprofile, left_on="time", right_on="time", how="outer"
+            )
             .set_index("index")
         )
         forecast = forecast[["load"]].rename(columns=dict(load="forecast"))

--- a/openstf/model/prediction/xgboost/quantile.py
+++ b/openstf/model/prediction/xgboost/quantile.py
@@ -126,7 +126,7 @@ class QuantileXGBPredictionModel(XGBPredictionModel):
         TODO: make hardcoded quantiles not hardcoded
 
         Args:
-            -forecast_index: pd.DatetimeIndex, used to determine new forecast timerange
+            - forecast_index: pd.DatetimeIndex, used to determine new forecast timerange
             - load: pd.DataFrame(DatetimeIndex, columns=[load])
 
         Returns:
@@ -135,6 +135,10 @@ class QuantileXGBPredictionModel(XGBPredictionModel):
 
         # Use default
         forecast = super().predict_fallback(forecast_index, load)
+
+        # Use the forecasted load since the actual load contains nan timestamps
+        # in the future
+        load = forecast[["forecast"]].rename(columns={"forecast":"load"})
 
         # Calculate quantiles per hour of day - list with items <1 can be copied from database
         quantiles = [x * 100 for x in [0.05, 0.1, 0.3, 0.5, 0.7, 0.9, 0.95]]

--- a/openstf/model/prediction/xgboost/quantile.py
+++ b/openstf/model/prediction/xgboost/quantile.py
@@ -138,7 +138,7 @@ class QuantileXGBPredictionModel(XGBPredictionModel):
 
         # Use the forecasted load since the actual load contains nan timestamps
         # in the future
-        load = forecast[["forecast"]].rename(columns={"forecast":"load"})
+        load = forecast[["forecast"]].rename(columns={"forecast": "load"})
 
         # Calculate quantiles per hour of day - list with items <1 can be copied from database
         quantiles = [x * 100 for x in [0.05, 0.1, 0.3, 0.5, 0.7, 0.9, 0.95]]


### PR DESCRIPTION
When making a fallback forecast for a quantile model the quantile columns contained nan values. This causes the write_forecast (to database) method to throw an exception.

The root cause of the problem seemed to be that the quantiles where calculated based on the future load. The future load is nan, so the quantiles became nan as well. I tried to solve this by using the forecasted load instead of the future load. Furthermore I made a couple small changes to the make_fallback_forecast method for redability and to prevent some pandas deprecated messages.

Let me know if you thinks this is the proper way to solve this issue.

![image](https://user-images.githubusercontent.com/6715707/117466759-5baad200-af53-11eb-9780-170da156ba7d.png)
