### PR TITLE
Bugfix #86 ktps 1424 calc kpi constant load

### DIFF
--- a/openstf/metrics/metrics.py
+++ b/openstf/metrics/metrics.py
@@ -48,7 +48,11 @@ def r_mae(realised, forecast):
     The range is based on the load range of the previous two weeks"""
 
     # Determine load range on entire dataset
-    range_ = realised.max() - realised.min() if (realised.max() - realised.min()) != 0 else np.nan
+    range_ = (
+        realised.max() - realised.min()
+        if (realised.max() - realised.min()) != 0
+        else np.nan
+    )
 
     return mae(realised, forecast) / range_
 
@@ -72,7 +76,11 @@ def r_mae_highest(realised, forecast, percentile=0.95):
         )
 
     # Determine load range on entire dataset
-    range_ = realised.max() - realised.min() if (realised.max() - realised.min()) != 0 else np.nan
+    range_ = (
+        realised.max() - realised.min()
+        if (realised.max() - realised.min()) != 0
+        else np.nan
+    )
 
     # Get highest percentile of values
     highest_values = realised > np.percentile(realised, percentile)
@@ -93,7 +101,11 @@ def r_mne_highest(realised, forecast):
     combined = pd.concat([realised, forecast], axis=1)
 
     # Determine load range on entire dataset
-    range_ = combined["load"].max() - combined["load"].min() if (combined["load"].max() - combined["load"].min()) != 0 else np.nan
+    range_ = (
+        combined["load"].max() - combined["load"].min()
+        if (combined["load"].max() - combined["load"].min()) != 0
+        else np.nan
+    )
 
     # Select 5 percent highest realised load values
     combined["highest"] = combined["load"][
@@ -126,7 +138,11 @@ def r_mpe_highest(realised, forecast):
     combined = pd.concat([realised, forecast], axis=1)
 
     # Determine load range on entire dataset
-    range_ = combined["load"].max() - combined["load"].min() if (combined["load"].max() - combined["load"].min()) != 0 else np.nan
+    range_ = (
+        combined["load"].max() - combined["load"].min()
+        if (combined["load"].max() - combined["load"].min()) != 0
+        else np.nan
+    )
 
     # Select 5 percent highest realised load values
     combined["highest"] = combined["load"][
@@ -154,7 +170,11 @@ def r_mae_lowest(realised, forecast, quantile=0.05):
     The range is based on the load range of the previous two weeks"""
 
     # Determine load range on entire dataset
-    range_ = realised.max() - realised.min() if (realised.max() - realised.min()) != 0 else np.nan
+    range_ = (
+        realised.max() - realised.min()
+        if (realised.max() - realised.min()) != 0
+        else np.nan
+    )
 
     # Get lowest percentile of values
     lowest_values = realised < np.quantile(realised, quantile)
@@ -205,7 +225,11 @@ def franks_skill_score(realised, forecast, basecase, range_=1.0):
     # Combine series in one DataFrame
     combined = pd.concat([realised, forecast], axis=1)
     if range_ == 1.0:
-        range_ = combined["load"].max() - combined["load"].min() if (combined["load"].max() - combined["load"].min()) != 0 else np.nan
+        range_ = (
+            combined["load"].max() - combined["load"].min()
+            if (combined["load"].max() - combined["load"].min()) != 0
+            else np.nan
+        )
 
     franks_skill_score = (mae(realised, basecase) - mae(realised, forecast)) / range_
 
@@ -219,7 +243,11 @@ def franks_skill_score_peaks(realised, forecast, basecase):
     # Combine series in one DataFrame
     combined = pd.concat([realised, forecast, basecase], axis=1)
 
-    range_ = combined["load"].max() - combined["load"].min() if (combined["load"].max() - combined["load"].min()) != 0 else np.nan
+    range_ = (
+        combined["load"].max() - combined["load"].min()
+        if (combined["load"].max() - combined["load"].min()) != 0
+        else np.nan
+    )
     # Select 5 percent highest realised load values
     combined["highest"] = combined["load"][
         combined["load"] > combined["load"].quantile(0.95)

--- a/openstf/metrics/metrics.py
+++ b/openstf/metrics/metrics.py
@@ -48,7 +48,7 @@ def r_mae(realised, forecast):
     The range is based on the load range of the previous two weeks"""
 
     # Determine load range on entire dataset
-    range_ = realised.max() - realised.min()
+    range_ = realised.max() - realised.min() if (realised.max() - realised.min()) != 0 else np.nan
 
     return mae(realised, forecast) / range_
 
@@ -72,7 +72,7 @@ def r_mae_highest(realised, forecast, percentile=0.95):
         )
 
     # Determine load range on entire dataset
-    range_ = realised.max() - realised.min()
+    range_ = realised.max() - realised.min() if (realised.max() - realised.min()) != 0 else np.nan
 
     # Get highest percentile of values
     highest_values = realised > np.percentile(realised, percentile)
@@ -93,7 +93,7 @@ def r_mne_highest(realised, forecast):
     combined = pd.concat([realised, forecast], axis=1)
 
     # Determine load range on entire dataset
-    range_ = combined["load"].max() - combined["load"].min()
+    range_ = combined["load"].max() - combined["load"].min() if (combined["load"].max() - combined["load"].min()) != 0 else np.nan
 
     # Select 5 percent highest realised load values
     combined["highest"] = combined["load"][
@@ -126,7 +126,7 @@ def r_mpe_highest(realised, forecast):
     combined = pd.concat([realised, forecast], axis=1)
 
     # Determine load range on entire dataset
-    range_ = combined["load"].max() - combined["load"].min()
+    range_ = combined["load"].max() - combined["load"].min() if (combined["load"].max() - combined["load"].min()) != 0 else np.nan
 
     # Select 5 percent highest realised load values
     combined["highest"] = combined["load"][
@@ -154,7 +154,7 @@ def r_mae_lowest(realised, forecast, quantile=0.05):
     The range is based on the load range of the previous two weeks"""
 
     # Determine load range on entire dataset
-    range_ = realised.max() - realised.min()
+    range_ = realised.max() - realised.min() if (realised.max() - realised.min()) != 0 else np.nan
 
     # Get lowest percentile of values
     lowest_values = realised < np.quantile(realised, quantile)
@@ -205,7 +205,7 @@ def franks_skill_score(realised, forecast, basecase, range_=1.0):
     # Combine series in one DataFrame
     combined = pd.concat([realised, forecast], axis=1)
     if range_ == 1.0:
-        range_ = combined["load"].max() - combined["load"].min()
+        range_ = combined["load"].max() - combined["load"].min() if (combined["load"].max() - combined["load"].min()) != 0 else np.nan
 
     franks_skill_score = (mae(realised, basecase) - mae(realised, forecast)) / range_
 
@@ -219,7 +219,7 @@ def franks_skill_score_peaks(realised, forecast, basecase):
     # Combine series in one DataFrame
     combined = pd.concat([realised, forecast, basecase], axis=1)
 
-    range_ = combined["load"].max() - combined["load"].min()
+    range_ = combined["load"].max() - combined["load"].min() if (combined["load"].max() - combined["load"].min()) != 0 else np.nan
     # Select 5 percent highest realised load values
     combined["highest"] = combined["load"][
         combined["load"] > combined["load"].quantile(0.95)

--- a/openstf/tasks/calculate_kpi.py
+++ b/openstf/tasks/calculate_kpi.py
@@ -165,7 +165,9 @@ def calc_kpi_for_specific_pid(pid, start_time=None, end_time=None):
 
     # Raise exception in case of constant load
     if combined.load.nunique() == 1:
-        structlog.get_logger().warning("The load is constant! KPIs will still be calculated, but relative metrics will be nan")
+        structlog.get_logger().warning(
+            "The load is constant! KPIs will still be calculated, but relative metrics will be nan"
+        )
 
     # Define output dictonary
     kpis = dict()

--- a/openstf/tasks/calculate_kpi.py
+++ b/openstf/tasks/calculate_kpi.py
@@ -165,7 +165,7 @@ def calc_kpi_for_specific_pid(pid, start_time=None, end_time=None):
 
     # Raise exception in case of constant load
     if combined.load.nunique() == 1:
-        raise ValueError("The load is constant!")
+        structlog.get_logger().warning("The load is constant! KPIs will still be calculated, but relative metrics will be nan")
 
     # Define output dictonary
     kpis = dict()

--- a/test/unit/tasks/test_calculate_kpi.py
+++ b/test/unit/tasks/test_calculate_kpi.py
@@ -99,8 +99,8 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
         """If load is constant, a warning should be raised, but kpi's should still be calculated"""
 
         kpis = calc_kpi_for_specific_pid({"id": 295})
-        self.assertIsNAN(kpis['4.0h']['MAE'])  # arbitrary time horizon tested
-        self.assertAlmostEqual(kpis['4.0h']['MAE'], 2.9145, places=3)
+        self.assertIsNAN(kpis["4.0h"]["MAE"])  # arbitrary time horizon tested
+        self.assertAlmostEqual(kpis["4.0h"]["MAE"], 2.9145, places=3)
 
 
 # Run all tests

--- a/test/unit/tasks/test_calculate_kpi.py
+++ b/test/unit/tasks/test_calculate_kpi.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from test.utils import BaseTestCase, TestData
-from unittest.mock import MagicMock, patch
 import unittest
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
 
 from openstf.tasks.calculate_kpi import calc_kpi_for_specific_pid
+from test.utils import BaseTestCase, TestData
 
 # Get test data
 predicted_load = TestData.load("calculate_kpi_predicted_load.csv")
@@ -23,6 +23,7 @@ realised_load_nan.loc[realised_load_nan.sample(frac=0.5).index, :] = np.NaN
 # Prepare dataframe with nans to test low completeness
 predicted_load_nan = predicted_load.copy()
 predicted_load_nan.loc[predicted_load_nan.sample(frac=0.5).index, :] = np.NaN
+
 
 # Prepare Database mocks
 
@@ -50,14 +51,16 @@ def get_database_mock_predicted_nan():
     db.get_prediction_job = MagicMock(return_value={"id": 295})
     return db
 
+
 def get_database_mock_realised_constant():
     db = MagicMock()
     realised_load_constant = realised_load.copy()
-    realised_load_constant.iloc[1:,:] = realised_load_constant.iloc[0,:]
+    realised_load_constant.iloc[1:, :] = realised_load_constant.iloc[0, :]
     db.get_load_pid = MagicMock(return_value=realised_load_constant)
     db.get_predicted_load_tahead = MagicMock(return_value=predicted_load)
     db.get_prediction_job = MagicMock(return_value={"id": 295})
     return db
+
 
 class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
 
@@ -96,7 +99,7 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
         """If load is constant, a warning should be raised, but kpi's should still be calculated"""
 
         kpis = calc_kpi_for_specific_pid({"id": 295})
-        self.assertIsNAN(kpis['4.0h']['MAE']) # arbitrary time horizon tested
+        self.assertIsNAN(kpis['4.0h']['MAE'])  # arbitrary time horizon tested
         self.assertAlmostEqual(kpis['4.0h']['MAE'], 2.9145, places=3)
 
 

--- a/test/unit/tasks/test_calculate_kpi.py
+++ b/test/unit/tasks/test_calculate_kpi.py
@@ -96,7 +96,8 @@ class TestPerformanceCalcKpiForSpecificPid(BaseTestCase):
         """If load is constant, a warning should be raised, but kpi's should still be calculated"""
 
         kpis = calc_kpi_for_specific_pid({"id": 295})
-
+        self.assertIsNAN(kpis['4.0h']['MAE']) # arbitrary time horizon tested
+        self.assertAlmostEqual(kpis['4.0h']['MAE'], 2.9145, places=3)
 
 
 # Run all tests


### PR DESCRIPTION
fixes #86 

First replicated bug by adding unit test, subsequently fixed the code to make the test pass.
As described in the issue, if the `load` is constant, force the `range_` to be nan. 
This will result in nan's for the relative metrics, as desired.