### PR TITLE
add fix and unit test

### DIFF
--- a/openstf/validation/validation.py
+++ b/openstf/validation/validation.py
@@ -133,7 +133,8 @@ def calc_completeness(df, weights=None, time_delayed=False, homogenise=True):
 
         non_na_count = df.count()
         for col, value in timecols.items():
-            non_na_count[col] += value
+            if value >= 0:
+                non_na_count[col] += value
 
         # Correct for APX being only expected to be available up to 24h
         if "APX" in non_na_count.index:

--- a/test/unit/validation/test_validation_calc_completeness.py
+++ b/test/unit/validation/test_validation_calc_completeness.py
@@ -123,7 +123,7 @@ class CalcCompletenessTest(BaseTestCase):
             },
         )
         completeness = calc_completeness(df, time_delayed=True)
-        self.assertEqual(completeness, 11/12.)
+        self.assertEqual(completeness, 11 / 12.0)
 
 
 if __name__ == "__main__":

--- a/test/unit/validation/test_validation_calc_completeness.py
+++ b/test/unit/validation/test_validation_calc_completeness.py
@@ -109,6 +109,22 @@ class CalcCompletenessTest(BaseTestCase):
         self.assertAlmostEqual(empty_compl_homogenise, 0.0)
         self.assertAlmostEqual(empty_compl_nohomogenise, 0.0)
 
+    def test_calc_completeness_no_negatives(self):
+        """Test added after bug.
+        If time delayed is True, T-7d gave a negative weight,
+        falsely resulting in a very low completeness"""
+        df = pd.DataFrame(
+            index=[0, 1, 3],
+            data={
+                "T-15min": [1, np.nan, np.nan],
+                "T-7d": [2, 3, 4],
+                "T-24d": [4, 5, 6],
+                "col1": [1, np.nan, 2],
+            },
+        )
+        completeness = calc_completeness(df, time_delayed=True)
+        self.assertEqual(completeness, 11/12.)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As discussed by phone.
There was a bug when calculating the completeness of T-7d. This would result in a negative completeness for this column, falsely resulting in a very low completeness overall.

I added a small unit test for this and fixed this behavior in the code.
I plan to also merge this hotfix to the sklearn branch after approvement