### PR TITLE
Hotfix fix python 37 38 compatibility

### DIFF
--- a/openstf/feature_engineering/lag_features.py
+++ b/openstf/feature_engineering/lag_features.py
@@ -66,12 +66,12 @@ def extract_lag_features(
     the training of the input model.
 
     Args:
-        feature_names (list[str]): All requested lag features
+        feature_names (List[str]): All requested lag features
         horizon (float): Forecast horizon limit in hours.
 
     Returns:
-        minutes_list (list[int]): list of minute lags that were used as features during training
-        days_list (list[int]): list of minute lags that were used as features during training
+        minutes_list (List[int]): list of minute lags that were used as features during training
+        days_list (List[int]): list of minute lags that were used as features during training
     """
 
     # Prepare empty lists to append on
@@ -106,8 +106,8 @@ def generate_trivial_lag_features(horizon: float) -> Tuple[list, list]:
         horizon: Forecast horizon limit in hours.
 
     Returns:
-        minutes_list (list[int]): list of minute lags that were used as features during training
-        days_list (list[int]): list of minute lags that were used as features during training
+        minutes_list (List[int]): list of minute lags that were used as features during training
+        days_list (List[int]): list of minute lags that were used as features during training
 
     """
     mindays = int(np.ceil(horizon / 24))

--- a/openstf/model/confidence_interval_applicator.py
+++ b/openstf/model/confidence_interval_applicator.py
@@ -3,13 +3,12 @@
 # SPDX-License-Identifier: MPL-2.0
 from datetime import datetime
 import pytz
+from typing import List
 
 import numpy as np
 import pandas as pd
 from scipy import stats
 from sklearn.base import RegressorMixin
-
-from openstf.enums import MLModelType
 
 MINIMAL_RESOLUTION: int = 15  # Minimal time resolution in minutes
 
@@ -159,7 +158,7 @@ class ConfidenceIntervalApplicator:
 
     @staticmethod
     def _add_quantiles_to_forecast_default(
-        forecast: pd.DataFrame, quantiles: list[float]
+        forecast: pd.DataFrame, quantiles: List[float]
     ) -> pd.DataFrame:
         """Add quantiles to forecast.
 
@@ -167,7 +166,7 @@ class ConfidenceIntervalApplicator:
 
         Args:
             forecast (pd.DataFrame): Forecast (should contain a 'forecast' + 'stdev' column)
-            quantiles (list): List with desired quantiles,
+            quantiles (List[float]): List with desired quantiles,
                 for example: [0.01, 0.1, 0.9, 0.99]
 
         Returns:
@@ -188,7 +187,7 @@ class ConfidenceIntervalApplicator:
         return forecast
 
     def _add_quantiles_to_forecast_quantile_regression(
-        self, forecast: pd.DataFrame, quantiles: list[float]
+        self, forecast: pd.DataFrame, quantiles: List[float]
     ) -> pd.DataFrame:
         """Add quantiles to forecast.
 
@@ -196,7 +195,7 @@ class ConfidenceIntervalApplicator:
 
         Args:
             forecast (pd.DataFrame): Forecast
-            quantiles (list): List with desired quantiles
+            quantiles (List[float]): List with desired quantiles
 
         Returns:
             (pd.DataFrame): Forecast DataFrame with quantile (e.g. 'quantile_PXX')

--- a/openstf/model/serializer.py
+++ b/openstf/model/serializer.py
@@ -140,6 +140,7 @@ class PersistentStorageSerializer(AbstractSerializer):
 
         # Add model age to model object
         loaded_model.age = model_age_in_days
+        loaded_model.path = model_path
 
         return loaded_model
 

--- a/openstf/model_selection/model_selection.py
+++ b/openstf/model_selection/model_selection.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2017-2021 Alliander N.V. <korte.termijn.prognoses@alliander.com> # noqa E501>
 #
 # SPDX-License-Identifier: MPL-2.0
-from typing import List
+from typing import List, Tuple
 from datetime import timedelta
 
 import numpy as np
@@ -16,7 +16,7 @@ def split_data_train_validation_test(
     backtest: bool = False,
     period_sampling: bool = True,
     period_timedelta: timedelta = timedelta(days=2),
-) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Split input data into train, test and validation set.
 
     Function for splitting cleaned data with features in a train, test and
@@ -139,7 +139,7 @@ def split_data_train_validation_test(
 
 def sample_validation_data_periods(
     data: pd.DataFrame, validation_fraction: float = 0.15, period_length: int = 192
-) -> tuple[pd.DataFrame, pd.DataFrame]:
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Splits data in train and validation dataset.
 
     Tries to sample random periods of given length to form a validation set of

--- a/openstf/pipeline/create_basecase_forecast.py
+++ b/openstf/pipeline/create_basecase_forecast.py
@@ -95,6 +95,7 @@ def create_basecase_forecast_pipeline(
     basecase_forecast = add_prediction_job_properties_to_forecast(
         pj=pj,
         forecast=basecase_forecast,
+        algorithm_type="basecase_lastweek",
         forecast_type=ForecastType.BASECASE,
         forecast_quality="not_renewed",
     )

--- a/openstf/pipeline/create_component_forecast.py
+++ b/openstf/pipeline/create_component_forecast.py
@@ -45,8 +45,7 @@ def create_components_forecast_pipeline(pj, input_data, weather_data, split_coef
 
     # Prepare for output
     forecasts = postprocessing.add_prediction_job_properties_to_forecast(
-        pj,
-        forecasts,
+        pj, forecasts, algorithm_type="component"
     )
 
     return forecasts

--- a/openstf/pipeline/create_forecast.py
+++ b/openstf/pipeline/create_forecast.py
@@ -113,6 +113,7 @@ def create_forecast_pipeline_core(
     forecast = add_prediction_job_properties_to_forecast(
         pj,
         forecast,
+        algorithm_type=str(model.path),
     )
 
     return forecast

--- a/openstf/pipeline/optimize_hyperparameters.py
+++ b/openstf/pipeline/optimize_hyperparameters.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 import pandas as pd
 import optuna
+from typing import List
 import structlog
 
 from openstf.model.objective_creator import ObjectiveCreator
@@ -19,13 +20,13 @@ logger = structlog.get_logger(__name__)
 # See https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.optimize
 N_TRIALS: int = 8  # The number of trials.
 TIMEOUT: int = 200  # Stop study after the given number of second(s).
-TRAIN_HORIZONS: list[float] = [0.25, 24.0]
+TRAIN_HORIZONS: List[float] = [0.25, 24.0]
 
 
 def optimize_hyperparameters_pipeline(
     pj: dict,
     input_data: pd.DataFrame,
-    horizons: list[float] = TRAIN_HORIZONS,
+    horizons: List[float] = TRAIN_HORIZONS,
     n_trials: int = N_TRIALS,
     timeout: int = TIMEOUT,
 ) -> dict:
@@ -34,7 +35,7 @@ def optimize_hyperparameters_pipeline(
     Args:
         pj (dict): Prediction job
         input_data (pd.DataFrame): Raw training input data
-        horizons (list[float]): horizons for feature engineering.
+        horizons (List[float]): horizons for feature engineering.
         n_trials (int, optional): The number of trials. Defaults to N_TRIALS.
         timeout (int, optional): Stop study after the given number of second(s).
             Defaults to TIMEOUT.

--- a/openstf/pipeline/train_create_forecast_backtest.py
+++ b/openstf/pipeline/train_create_forecast_backtest.py
@@ -58,8 +58,7 @@ def train_model_and_forecast_back_test(
 
     # Prepare for output
     forecast = add_prediction_job_properties_to_forecast(
-        pj,
-        forecast,
+        pj, forecast, algorithm_type="backtest"
     )
 
     # Add column with realised load and horizon information

--- a/openstf/pipeline/train_model.py
+++ b/openstf/pipeline/train_model.py
@@ -111,7 +111,7 @@ def train_model_pipeline_core(
         RuntimeError: When old model is better than new model
 
     Returns:
-        tuple[RegressorMixin, Report]: Trained model and report (with figures)
+        Tuple[RegressorMixin, Report]: Trained model and report (with figures)
     """
 
     if horizons is None:
@@ -181,7 +181,7 @@ def train_pipeline_common(
         horizons (List[float]): horizons to train on in hours.
 
     Returns:
-        tuple[RegressorMixin, pd.DataFrame, pd.DataFrame, pd.DataFrame]: Trained model,
+        Tuple[RegressorMixin, pd.DataFrame, pd.DataFrame, pd.DataFrame]: Trained model,
          train_data, validation_data and test_data
 
 

--- a/openstf/pipeline/utils.py
+++ b/openstf/pipeline/utils.py
@@ -1,12 +1,13 @@
 # SPDX-FileCopyrightText: 2017-2021 Alliander N.V. <korte.termijn.prognoses@alliander.com> # noqa E501>
 #
 # SPDX-License-Identifier: MPL-2.0
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+from typing import Tuple
 
 
 def generate_forecast_datetime_range(
     resolution_minutes: int, horizon_minutes: int
-) -> tuple[datetime, datetime]:
+) -> Tuple[datetime, datetime]:
     # get current date and time UTC
     datetime_utc = datetime.utcnow()
     # Datetime range for time interval to be predicted

--- a/openstf/postprocessing/postprocessing.py
+++ b/openstf/postprocessing/postprocessing.py
@@ -178,10 +178,14 @@ def add_components_base_case_forecast(basecase_forecast: pd.DataFrame) -> pd.Dat
 def add_prediction_job_properties_to_forecast(
     pj: dict,
     forecast: pd.DataFrame,
+    algorithm_type: str,
     forecast_type: Enum = None,
     forecast_quality: str = None,
 ) -> pd.DataFrame:
-    # self.logger.info("Postproces in preparation of storing")
+
+    logger = structlog.get_logger(__name__)
+
+    logger.info("Postproces in preparation of storing")
     if forecast_type is None:
         forecast_type = pj["typ"]
     else:
@@ -201,6 +205,6 @@ def add_prediction_job_properties_to_forecast(
     forecast["customer"] = pj["name"]
     forecast["description"] = pj["description"]
     forecast["type"] = forecast_type
-    forecast["algtype"] = pj["model"]
+    forecast["algtype"] = algorithm_type
 
     return forecast

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstf",
-    version="2.0.1a1",
+    version="2.0.1",
     packages=find_packages(include=["openstf", "openstf.*"]),
     description="Open short term forcasting",
     long_description=read_long_description_from_readme(),

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstf",
-    version="2.0.0",
+    version="2.0.1a1",
     packages=find_packages(include=["openstf", "openstf.*"]),
     description="Open short term forcasting",
     long_description=read_long_description_from_readme(),


### PR DESCRIPTION
This PR will fix Python 3.7 and Python 3.8 incompatibilites with `list[float], tuple[int]` etc. For now we are just going to use the `from typing import List` type hints.