### PR TITLE
Bugfix always sort index after applying horizons

### DIFF
--- a/openstf/feature_engineering/feature_applicator.py
+++ b/openstf/feature_engineering/feature_applicator.py
@@ -62,7 +62,8 @@ class TrainFeatureApplicator(AbstractFeatureApplicator):
                 {"APX": 24}
 
         Returns:
-            pd.DataFrame: Input DataFrame with an extra column for every added feature.
+            pd.DataFrame: Input DataFrame with an extra column for every added feature
+                and sorted on the datetime index.
         """
 
         if latency_config is None:
@@ -77,11 +78,15 @@ class TrainFeatureApplicator(AbstractFeatureApplicator):
 
         # Loop over horizons and add corresponding features
         for horizon in self.horizons:
-            res = apply_features(
-                df.copy(deep=True), horizon=horizon
-            )  # Deep copy of df is important, because we want a fresh start every iteration!
+            # Deep copy of df is important, because we want a fresh start every iteration!
+            res = apply_features(df.copy(deep=True), horizon=horizon)
             res["horizon"] = horizon
             result = result.append(res)
+
+        # IMPORTANT: sort index to prevent errors when slicing on the (datetime) index
+        # if we don't sort, the duplicated indexes (one per horizon) have large gaps
+        # and slicing with given an exception.
+        result = result.sort_index(axis=0)
 
         # Invalidate features that are not available for a specific horizon due to data
         # latency

--- a/openstf/feature_engineering/feature_applicator.py
+++ b/openstf/feature_engineering/feature_applicator.py
@@ -85,7 +85,7 @@ class TrainFeatureApplicator(AbstractFeatureApplicator):
 
         # IMPORTANT: sort index to prevent errors when slicing on the (datetime) index
         # if we don't sort, the duplicated indexes (one per horizon) have large gaps
-        # and slicing with given an exception.
+        # and slicing will give an exception.
         result = result.sort_index(axis=0)
 
         # Invalidate features that are not available for a specific horizon due to data

--- a/openstf/model/confidence_interval_applicator.py
+++ b/openstf/model/confidence_interval_applicator.py
@@ -115,7 +115,7 @@ class ConfidenceIntervalApplicator:
             # Determine now, rounded on 15 minutes,
             # Rounding helps to prevent fractional t_aheads
             now = (
-                pd.Series(datetime.utcnow().replace(tzinfo=pytz.utc))
+                pd.Series(datetime.utcnow().replace(tzinfo=forecast_copy.index.tzinfo))
                 .min()
                 .round(f"{MINIMAL_RESOLUTION}T")
                 .to_pydatetime()
@@ -123,7 +123,6 @@ class ConfidenceIntervalApplicator:
             # Determin t_aheads by subtracting with now
             forecast_copy["tAhead"] = (forecast_copy.index - now).total_seconds() / 3600.0
 
-        breakpoint()
         # add helper column hour
         forecast_copy["hour"] = forecast_copy.index.hour
 

--- a/openstf/model/confidence_interval_applicator.py
+++ b/openstf/model/confidence_interval_applicator.py
@@ -120,11 +120,10 @@ class ConfidenceIntervalApplicator:
                 .round(f"{MINIMAL_RESOLUTION}T")
                 .to_pydatetime()
             )
-
             # Determin t_aheads by subtracting with now
-            forecast_copy["tAhead"] = (
-                forecast_copy.index - now
-            ).total_seconds() / 3600.0
+            forecast_copy["tAhead"] = (forecast_copy.index - now).total_seconds() / 3600.0
+
+        breakpoint()
         # add helper column hour
         forecast_copy["hour"] = forecast_copy.index.hour
 

--- a/openstf/model/xgb_quantile.py
+++ b/openstf/model/xgb_quantile.py
@@ -10,7 +10,6 @@ import xgboost as xgb
 from xgboost import Booster
 import numpy as np
 
-
 import openstf.metrics.metrics as metrics
 
 DEFAULT_QUANTILES: Tuple[float, ...] = (0.9, 0.5, 0.1)

--- a/openstf/pipeline/create_basecase_forecast.py
+++ b/openstf/pipeline/create_basecase_forecast.py
@@ -4,7 +4,8 @@
 from pathlib import Path
 
 import pandas as pd
-from datetime import timedelta
+from datetime import timedelta, tzinfo
+import pytz
 import structlog
 from openstf.enums import ForecastType
 from openstf.feature_engineering.feature_applicator import (
@@ -54,9 +55,9 @@ def create_basecase_forecast_pipeline(
     # Make sure forecast interval is available in the input interval
 
     # Start of the new range is start of the input interval
-    new_start = validated_data.index.min().to_pydatetime()
+    new_start = validated_data.index.min().to_pydatetime().replace(tzinfo=pytz.utc)
     # End of the new range is end of the forecast interval
-    new_end = forecast_end.replace(tzinfo=new_start.tzinfo)
+    new_end = forecast_end.replace(tzinfo=pytz.utc)
     # Resample to the desired time resolution
     freq = f'{pj["resolution_minutes"]}T'
 

--- a/openstf/pipeline/create_forecast.py
+++ b/openstf/pipeline/create_forecast.py
@@ -28,7 +28,10 @@ def create_forecast_pipeline(
 ) -> pd.DataFrame:
     """Create forecast pipeline
 
-     This is the top-level pipeline which included loading the most recent model for the given prediction job.
+    This is the top-level pipeline which included loading the most recent model for
+    the given prediction job.
+
+    Expected prediction job keys: "id",
 
     Args:
         pj (dict): Prediction job
@@ -55,6 +58,9 @@ def create_forecast_pipeline_core(
 
     Computes the forecasts and confidence intervals given a prediction job and input data.
     This pipeline has no database or persisitent storage dependencies.
+
+    Expected prediction job keys: "resolution_minutes", "horizon_minutes", "id", "type",
+        "name", "model_type_group", "quantiles"
 
     Args:
         pj (dict): Prediction job.

--- a/openstf/pipeline/optimize_hyperparameters.py
+++ b/openstf/pipeline/optimize_hyperparameters.py
@@ -32,6 +32,8 @@ def optimize_hyperparameters_pipeline(
 ) -> dict:
     """Optimize hyperparameters pipeline.
 
+    Expected prediction job key's: "name", "model"
+
     Args:
         pj (dict): Prediction job
         input_data (pd.DataFrame): Raw training input data

--- a/openstf/pipeline/train_model.py
+++ b/openstf/pipeline/train_model.py
@@ -33,6 +33,9 @@ def train_model_pipeline(
 ) -> None:
     """Midle level pipeline that takes care of all persistent storage dependencies
 
+    Expected prediction jobs keys: "id", "name", "model", "hyper_params",
+        "feature_names"
+
     Args:
         pj (dict): Prediction job
         input_data (pd.DataFrame): Raw training input data

--- a/openstf/pipeline/train_model.py
+++ b/openstf/pipeline/train_model.py
@@ -153,7 +153,7 @@ def train_model_pipeline_core(
                 "New model is better than old model, continuing with training procces"
             )
         except ValueError as e:
-            logging.info(f"Could not compare to old model", exc_info=e)
+            logging.info("Could not compare to old model", exc_info=e)
 
     # Do confidence interval determination
     model = StandardDeviationGenerator(
@@ -204,7 +204,7 @@ def train_pipeline_common(
 
     # Split data
     train_data, validation_data, test_data = split_data_train_validation_test(
-        data_with_features.sort_index(axis=0),
+        data_with_features,
         test_fraction=test_fraction,
         backtest=backtest,
     )

--- a/openstf/tasks/create_forecast.py
+++ b/openstf/tasks/create_forecast.py
@@ -69,10 +69,12 @@ def create_forecast_task(pj: dict, context: TaskContext) -> None:
     context.database.write_forecast(forecast, t_ahead_series=True)
 
 
-def main():
-    with TaskContext("create_forecast") as context:
+def main(model_type=None):
+
+    if model_type is None:
         model_type = ["xgb", "xgb_quantile", "lgb"]
 
+    with TaskContext("create_forecast") as context:
         # status file callback after every iteration
         # TODO change implementation to a database one
         def callback(pj, successful):

--- a/openstf/tasks/create_forecast.py
+++ b/openstf/tasks/create_forecast.py
@@ -43,6 +43,9 @@ def create_forecast_task(pj: dict, context: TaskContext) -> None:
 
     On this task level all database and context manager dependencies are resolved.
 
+    Expected prediction job keys: "id", "lat", "lon", "resolution_minutes",
+        "horizon_minutes", "type", "name", "model_type_group", "quantiles"
+
     Args:
         pj (dict): Prediction job
         context (TaskContext): Contect object that holds a config manager and a database connection

--- a/openstf/tasks/optimize_hyperparameters.py
+++ b/openstf/tasks/optimize_hyperparameters.py
@@ -27,6 +27,15 @@ MAX_AGE_HYPER_PARAMS_DAYS = 31
 
 
 def optimize_hyperparameters_task(pj: dict, context: TaskContext) -> None:
+    """Optimize hyperparameters task.
+
+    Expected prediction job keys: "id", "model", "lat", "lon", "name", "description"
+    Only used for logging: "name", "description"
+
+    Args:
+        pj (dict): Prediction job
+        context (TaskContext): Task context
+    """
 
     # Determine if we need to optimize hyperparams
     datetime_last_optimized = context.database.get_hyper_params_last_optimized(pj)
@@ -41,7 +50,7 @@ def optimize_hyperparameters_task(pj: dict, context: TaskContext) -> None:
         )
         return
 
-    # Get input data
+    # Get input data (usese "id" and "model")
     current_hyperparams = context.database.get_hyper_params(pj)
     # TODO this conversion should be done in the database
     training_period_days = int(current_hyperparams["training_period_days"])

--- a/openstf/tasks/train_model.py
+++ b/openstf/tasks/train_model.py
@@ -36,12 +36,17 @@ DEFAULT_CHECK_MODEL_AGE: bool = True
 def train_model_task(
     pj: dict, context: TaskContext, check_old_model_age: bool = DEFAULT_CHECK_MODEL_AGE
 ) -> None:
-    """Top level task that trains a new model and makes sure the beast available model is stored.
-    On this task level all database and context manager dependencies are resolved.
+    """Train model task.
+
+    Top level task that trains a new model and makes sure the beast available model is
+    stored. On this task level all database and context manager dependencies are resolved.
+
+    Expected prediction job keys:  "id", "model", "lat", "lon", "name"
 
     Args:
         pj (dict): Prediction job
-        context (TaskContext): Contect object that holds a config manager and a database connection
+        context (TaskContext): Contect object that holds a config manager and a
+            database connection.
         check_old_model_age (bool): check if model is too young to be retrained
     """
 

--- a/openstf/tasks/train_model.py
+++ b/openstf/tasks/train_model.py
@@ -90,10 +90,12 @@ def train_model_task(
     context.perf_meter.checkpoint("Model trained")
 
 
-def main():
-    with TaskContext("train_model") as context:
+def main(model_type=None):
+
+    if model_type is None:
         model_type = ["xgb", "xgb_quantile", "lgb"]
 
+    with TaskContext("train_model") as context:
         PredictionJobLoop(context, model_type=model_type).map(train_model_task, context)
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstf",
-    version="2.0.4",
+    version="2.1.0",
     packages=find_packages(include=["openstf", "openstf.*"]),
     description="Open short term forcasting",
     long_description=read_long_description_from_readme(),

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read_long_description_from_readme():
 
 setup(
     name="openstf",
-    version="2.0.3",
+    version="2.0.4",
     packages=find_packages(include=["openstf", "openstf.*"]),
     description="Open short term forcasting",
     long_description=read_long_description_from_readme(),


### PR DESCRIPTION
Changelog

* always sort the index after adding feature for multiple horizons
* use the forecast tzinfo format when add the tAhead column
* Use pytz.utc for the create_basecase_forecast pipeline
* Add documentation on the expected/required keys in prediction jobs for multiple functions/methods
* Add option to set model_type when calling main() of
    * create_forecast task
    * train_model task