### PR TITLE
Bugfix check model age before getting inputs (KTPS-1479)

### DIFF
--- a/openstf/model/serializer.py
+++ b/openstf/model/serializer.py
@@ -154,12 +154,15 @@ class PersistentStorageSerializer(AbstractSerializer):
 
         return loaded_model
 
-    def determine_model_age_from_pid(self, pid) -> float:
+    def determine_model_age_from_pid(self, pid: int) -> float:
         """Determine model age in days of most recent model for a given pid.
         If no previous model is found, float(Inf) is returned
 
+        Args:
+            pid: int
+
         Returns:
-            object: """
+            float: model age in days"""
         model_path = self.find_most_recent_model_path(pid)
         model_age_days = self._determine_model_age_from_path(model_path)
         return model_age_days

--- a/openstf/model/serializer.py
+++ b/openstf/model/serializer.py
@@ -113,8 +113,13 @@ class PersistentStorageSerializer(AbstractSerializer):
         elif model_id is not None:
             model_path = self.convert_model_id_into_model_path(model_id)
 
-        if model_path is None or model_path.is_file() is False:
-            msg = f"No model file found at save location: '{model_path}'"
+        if model_path is None:
+            msg = f"No (most recent) model found"
+            self.logger.error(msg)
+            raise FileNotFoundError(msg)
+
+        if model_path.is_file() is False:
+            msg = f"model_path is not a file ({model_path})"
             self.logger.error(msg)
             raise FileNotFoundError(msg)
 

--- a/openstf/model/serializer.py
+++ b/openstf/model/serializer.py
@@ -164,7 +164,10 @@ class PersistentStorageSerializer(AbstractSerializer):
         Returns:
             float: model age in days"""
         model_path = self.find_most_recent_model_path(pid)
-        model_age_days = self._determine_model_age_from_path(model_path)
+        if model_path is not None:
+            model_age_days = self._determine_model_age_from_path(model_path)
+        else:
+            model_age_days = float("Inf")
         return model_age_days
 
     def _determine_model_age_from_path(self, model_path: Path) -> float:

--- a/openstf/model/serializer.py
+++ b/openstf/model/serializer.py
@@ -18,6 +18,11 @@ MODEL_ID_SEP = "-"
 
 class AbstractSerializer(ABC):
     def __init__(self, trained_models_folder: Union[Path, str]) -> None:
+        """
+
+        Returns:
+            object:
+        """
         self.logger = structlog.get_logger(self.__class__.__name__)
         self.trained_models_folder = trained_models_folder
 
@@ -148,6 +153,17 @@ class PersistentStorageSerializer(AbstractSerializer):
         loaded_model.path = model_path
 
         return loaded_model
+
+    def determine_model_age_from_pid(self, pid) -> float:
+        """Determine model age in days of most recent model for a given pid.
+        If no previous model is found, float(Inf) is returned
+
+        Returns:
+            object: """
+        model_path = self.find_most_recent_model_path(pid)
+        model_age_days = self._determine_model_age_from_path(model_path)
+        return model_age_days
+
 
     def _determine_model_age_from_path(self, model_path: Path) -> float:
         """Determines how many days ago a model is trained base on the folder name.

--- a/openstf/pipeline/train_model.py
+++ b/openstf/pipeline/train_model.py
@@ -248,15 +248,14 @@ def train_pipeline_common(
     ).generate_standard_deviation_data(model)
     return model, train_data, validation_data, test_data
 
+
 def get_model_age(trained_models_folder, pid):
     serializer = PersistentStorageSerializer(trained_models_folder)
 
     # Get old model and age
     try:
         old_model = serializer.load_model(pid=pid)
-        old_model_age = (
-            old_model.age
-        )
+        old_model_age = old_model.age
     except FileNotFoundError:
         old_model = None
         old_model_age = float("inf")

--- a/openstf/pipeline/train_model.py
+++ b/openstf/pipeline/train_model.py
@@ -249,14 +249,15 @@ def train_pipeline_common(
     return model, train_data, validation_data, test_data
 
 
-def get_model_age(trained_models_folder, pid):
-    serializer = PersistentStorageSerializer(trained_models_folder)
+def get_model_age(trained_models_folder: str, pid: int) -> float:
+    """returns age of most recently trained model in days.
+    If no previous model can be found, this returns float(inf).
 
-    # Get old model and age
-    try:
-        old_model = serializer.load_model(pid=pid)
-        old_model_age = old_model.age
-    except FileNotFoundError:
-        old_model = None
-        old_model_age = float("inf")
-    return old_model_age
+    Args:
+        trained_models_folder: str
+        pid: int
+
+    Returns:
+        float: age of most recent model in days"""
+    serializer = PersistentStorageSerializer(trained_models_folder)
+    return serializer.determine_model_age_from_pid(pid)

--- a/openstf/pipeline/train_model.py
+++ b/openstf/pipeline/train_model.py
@@ -244,3 +244,17 @@ def train_pipeline_common(
         pj, validation_data
     ).generate_standard_deviation_data(model)
     return model, train_data, validation_data, test_data
+
+def get_model_age(trained_models_folder, pid):
+    serializer = PersistentStorageSerializer(trained_models_folder)
+
+    # Get old model and age
+    try:
+        old_model = serializer.load_model(pid=pid)
+        old_model_age = (
+            old_model.age
+        )
+    except FileNotFoundError:
+        old_model = None
+        old_model_age = float("inf")
+    return old_model_age

--- a/openstf/tasks/train_model.py
+++ b/openstf/tasks/train_model.py
@@ -25,7 +25,11 @@ Example:
 from pathlib import Path
 from datetime import datetime, timedelta
 
-from openstf.pipeline.train_model import train_model_pipeline, MAXIMUM_MODEL_AGE, get_model_age
+from openstf.pipeline.train_model import (
+    train_model_pipeline,
+    MAXIMUM_MODEL_AGE,
+    get_model_age,
+)
 from openstf.tasks.utils.predictionjobloop import PredictionJobLoop
 from openstf.tasks.utils.taskcontext import TaskContext
 
@@ -67,11 +71,14 @@ def train_model_task(
 
     # If required, let's check the old model age before retrieving all the input data
     if check_old_model_age:
-        old_model_age = get_model_age(trained_models_folder, pj.get('id'))
-        context.logger.debug(f'Old model age: {old_model_age}')
+        old_model_age = get_model_age(trained_models_folder, pj.get("id"))
+        context.logger.debug(f"Old model age: {old_model_age}")
         if old_model_age < MAXIMUM_MODEL_AGE:
             # Old model is new enough. Skip this pj
-            context.logger.info(f'Old model was new enough, skipping ({old_model_age}<{MAXIMUM_MODEL_AGE})', pid=pj.get('id'))
+            context.logger.info(
+                f"Old model was new enough, skipping ({old_model_age}<{MAXIMUM_MODEL_AGE})",
+                pid=pj.get("id"),
+            )
             return
 
     context.perf_meter.checkpoint("Added metadata to PredictionJob")
@@ -102,6 +109,7 @@ def train_model_task(
     )
 
     context.perf_meter.checkpoint("Model trained")
+
 
 def main(model_type=None):
     if model_type is None:

--- a/openstf/tasks/train_model.py
+++ b/openstf/tasks/train_model.py
@@ -25,7 +25,7 @@ Example:
 from pathlib import Path
 from datetime import datetime, timedelta
 
-from openstf.pipeline.train_model import train_model_pipeline
+from openstf.pipeline.train_model import train_model_pipeline, MAXIMUM_MODEL_AGE, get_model_age
 from openstf.tasks.utils.predictionjobloop import PredictionJobLoop
 from openstf.tasks.utils.taskcontext import TaskContext
 
@@ -56,6 +56,19 @@ def train_model_task(
         pj["hyper_params"]["featureset_name"]
     )
 
+    # Get the paths for storing model and reports from the config manager
+    trained_models_folder = Path(context.config.paths.trained_models_folder)
+    save_figures_folder = Path(context.config.paths.webroot) / str(pj["id"])
+
+    # If required, let's check the old model age before retrieving all the input data
+    if check_old_model_age:
+        old_model_age = get_model_age(trained_models_folder, pj.get('id'))
+        context.logger.debug(f'Old model age: {old_model_age}')
+        if old_model_age < MAXIMUM_MODEL_AGE:
+            # Old model is new enough. Skip this pj
+            context.logger.info(f'Old model was new enough, skipping ({old_model_age}<{MAXIMUM_MODEL_AGE})', pid=pj.get('id'))
+            return
+
     context.perf_meter.checkpoint("Added metadata to PredictionJob")
 
     # Define start and end of the training input data
@@ -74,21 +87,16 @@ def train_model_task(
 
     context.perf_meter.checkpoint("Retrieved timeseries input")
 
-    # Get the paths for storing model and reports from the config manager
-    trained_models_folder = Path(context.config.paths.trained_models_folder)
-    save_figures_folder = Path(context.config.paths.webroot) / str(pj["id"])
-
     # Excecute the model training pipeline
     train_model_pipeline(
         pj,
         input_data,
-        check_old_model_age=check_old_model_age,
+        check_old_model_age=False,  # Old model age is already checked
         trained_models_folder=trained_models_folder,
         save_figures_folder=save_figures_folder,
     )
 
     context.perf_meter.checkpoint("Model trained")
-
 
 def main():
     with TaskContext("train_model") as context:

--- a/openstf/tasks/utils/predictionjobloop.py
+++ b/openstf/tasks/utils/predictionjobloop.py
@@ -121,7 +121,11 @@ class PredictionJobLoop:
             )
 
             self.context.perf_meter.start_level(
-                "iteration", i, num_jobs=num_jobs, pid=prediction_job.get("id"), **kwargs
+                "iteration",
+                i,
+                num_jobs=num_jobs,
+                pid=prediction_job.get("id"),
+                **kwargs
             )
 
             try:

--- a/openstf/tasks/utils/predictionjobloop.py
+++ b/openstf/tasks/utils/predictionjobloop.py
@@ -121,7 +121,7 @@ class PredictionJobLoop:
             )
 
             self.context.perf_meter.start_level(
-                "iteration", i, num_jobs=num_jobs, **kwargs
+                "iteration", i, num_jobs=num_jobs, pid=prediction_job.get("id"), **kwargs
             )
 
             try:

--- a/test/unit/tasks/test_train_model.py
+++ b/test/unit/tasks/test_train_model.py
@@ -27,9 +27,13 @@ class TestTrainModelTask(TestCase):
             train_model_pipeline_mock.call_args_list[0][0][0]["id"], self.pj["id"]
         )
 
-    @patch("openstf.tasks.train_model.get_model_age", return_value=MAXIMUM_MODEL_AGE-1)
+    @patch(
+        "openstf.tasks.train_model.get_model_age", return_value=MAXIMUM_MODEL_AGE - 1
+    )
     @patch("openstf.tasks.train_model.train_model_pipeline")
-    def test_train_model_task_recent_old_model(self, train_model_pipeline_mock, get_model_age_mock):
+    def test_train_model_task_recent_old_model(
+        self, train_model_pipeline_mock, get_model_age_mock
+    ):
         """If an old model exists which is recent, abort the training immediately."""
         # Test happy flow of create forecast task
         context = MagicMock()
@@ -37,14 +41,16 @@ class TestTrainModelTask(TestCase):
         # Assert that the context is not called. This would be the case if input data was retrieved
         context.database.get_model_input.assert_not_called()
 
-    @patch("openstf.tasks.train_model.get_model_age", return_value=MAXIMUM_MODEL_AGE+1)
+    @patch(
+        "openstf.tasks.train_model.get_model_age", return_value=MAXIMUM_MODEL_AGE + 1
+    )
     @patch("openstf.tasks.train_model.train_model_pipeline")
-    def test_train_model_task_no_recent_old_model(self, train_model_pipeline_mock, get_model_age_mock):
+    def test_train_model_task_no_recent_old_model(
+        self, train_model_pipeline_mock, get_model_age_mock
+    ):
         """If an old model exists but is not recent, training should continue."""
         # Test happy flow of create forecast task
         context = MagicMock()
         train_model_task(self.pj, context)
         # Assert that the context is called. This would be the case if input data was retrieved
         context.database.get_model_input.assert_called()
-
-

--- a/test/unit/tasks/test_train_model.py
+++ b/test/unit/tasks/test_train_model.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from openstf.tasks.train_model import train_model_task
+from openstf.pipeline.train_model import MAXIMUM_MODEL_AGE
 
 from test.utils import TestData
 
@@ -25,3 +26,25 @@ class TestTrainModelTask(TestCase):
         self.assertEqual(
             train_model_pipeline_mock.call_args_list[0][0][0]["id"], self.pj["id"]
         )
+
+    @patch("openstf.tasks.train_model.get_model_age", return_value=MAXIMUM_MODEL_AGE-1)
+    @patch("openstf.tasks.train_model.train_model_pipeline")
+    def test_train_model_task_recent_old_model(self, train_model_pipeline_mock, get_model_age_mock):
+        """If an old model exists which is recent, abort the training immediately."""
+        # Test happy flow of create forecast task
+        context = MagicMock()
+        train_model_task(self.pj, context)
+        # Assert that the context is not called. This would be the case if input data was retrieved
+        context.database.get_model_input.assert_not_called()
+
+    @patch("openstf.tasks.train_model.get_model_age", return_value=MAXIMUM_MODEL_AGE+1)
+    @patch("openstf.tasks.train_model.train_model_pipeline")
+    def test_train_model_task_no_recent_old_model(self, train_model_pipeline_mock, get_model_age_mock):
+        """If an old model exists but is not recent, training should continue."""
+        # Test happy flow of create forecast task
+        context = MagicMock()
+        train_model_task(self.pj, context)
+        # Assert that the context is called. This would be the case if input data was retrieved
+        context.database.get_model_input.assert_called()
+
+


### PR DESCRIPTION
fixes KTPS-1479

Move the check of the age of the most recent model to the point in the pipeline *before* loading all the input data.
To do this, I made a function 'get_model_age' in pipeline/train_model, which is called from task/train_model.
Please have a look at `openstf/tasks/train_model.py` for this implementation

This way, it does mean that the task/train_model uses a function which depends on the model_serializer.
However, since this is covered in a seperate function, if in the future we move to a different way of loading/storing models, this can be changed in a single location.

I also included two unit tests to check behavior in case there does and does not exist a recent model