### PR TITLE
add waiting for black step

### DIFF
--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -15,6 +15,14 @@ jobs:
         python-version: [3.9]
 
     steps:
+    # Wait on other action to finish before starting
+    - name: Wait for black-action to finish
+      uses: lewagon/wait-on-check-action@v0.2
+      with:
+        ref: ${{ github.ref }}
+        check-name: 'Black Format Code'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        wait-interval: 10
     # Checkout
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/python-build.yaml
+++ b/.github/workflows/python-build.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Wait for black-action to finish
       uses: lewagon/wait-on-check-action@v0.2
       with:
-        ref: ${{ github.ref }}
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
         check-name: 'Black Format Code'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 10


### PR DESCRIPTION
The action 'python build' and 'Black Format Code' start at the same time.
However, if Black formats the code, the codebase is changed during the executing of python build. Therefore the check does not show a nice green tick.
Let's try to make python build wait for black to finish. 